### PR TITLE
Form error on boot

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ On Debian, you can run ::
 
 You can then install django and the dependencies ::
 
- pip install django django-tables2 South GitPython pyinotify daemon Pygments django-bootstrap3 requests django-revproxy psutil pytz
+ pip install -r requirements.txt
 
 It has been reported that on some Debian system forcing a recent GitPython is required ::
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+daemon==1.1
+Django==1.8
+django-bootstrap3==5.4.0
+django-revproxy==0.9.0
+django-tables2==0.16.0
+gitdb==0.6.4
+GitPython==1.0.0
+psutil==2.2.1
+Pygments==2.0.2
+pytz==2015.2
+requests==2.6.0
+six==1.9.0
+smmap==0.9.0
+South==1.0.2
+urllib3==1.10.1
+# pyinotify

--- a/rules/forms.py
+++ b/rules/forms.py
@@ -25,6 +25,7 @@ from datetime import datetime
 class SystemSettingsForm(forms.ModelForm):
     class Meta:
         model = SystemSettings
+        exclude = []
 
 class SourceForm(forms.ModelForm):
     file  = forms.FileField(required = False)


### PR DESCRIPTION
I checked out the code and tried running the application on my OSX machine and got an error about a Form not being properly specified:

![image](https://cloud.githubusercontent.com/assets/693059/7263296/2b9bace2-e835-11e4-89f8-44db3d466812.png)

I have added the bare minimum to get the app booting again. Also includes a frozen dependency tree for `requirements.txt`. This requirements file is very useful for tracking dependencies and will make it easier for new users to get started. In place of copying a pip command they can run `pip install -r requirements.txt` and be guaranteed a set of libraries which will work. Read more here: https://pip.pypa.io/en/latest/user_guide.html#requirements-files