### PR TITLE
rules: add extensibility point in base html for sub-nav content

### DIFF
--- a/rules/templates/rules/base.html
+++ b/rules/templates/rules/base.html
@@ -84,6 +84,7 @@
 </div>
 </div>
 	</nav>
+	{% block subnavigation %} {% endblock %}
 	<div class="row">
 		<div class="col-md-2 col-sm-3">
 			<div class="panel panel-default" id="sidebar">


### PR DESCRIPTION
Extending the base html template before the sidebar allows for more varied navigation schemes.