### PR TITLE
suricata:fix error for judement that suricata list is empty

### DIFF
--- a/suricata/common.py
+++ b/suricata/common.py
@@ -255,7 +255,8 @@ config classification: default-login-attempt,Attempt to login by a default usern
     def get_system_config_buffer(self):
         from suricata.models import Suricata
         suricata = Suricata.objects.all()
-        if suricata == None:
+        #suricata list is empty
+        if len(suricata) == 0:
             return None
         suricata = suricata[0]
         config_buffer = None


### PR DESCRIPTION
suricata is a list,it can not judge nothing by None.
otherwise,it case this error:
Traceback:
File "/usr/local/lib/python2.7/dist-packages/django/core/handlers/base.py" in get_response
132. response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/home/yerx/scirius-newest/rules/views.py" in test_source
819. return HttpResponse(json.dumps(sourceatversion.test()), content_type="application/json")
File "/home/yerx/scirius-newest/rules/models.py" in test
621. return self.test_rule_buffer(rule_buffer)
File "/home/yerx/scirius-newest/rules/models.py" in test_rule_buffer
617. return testor.rules(rule_buffer, related_files = related_files)
File "/home/yerx/scirius-newest/suricata/common.py" in rules
287. config_buffer = self.get_system_config_buffer()
File "/home/yerx/scirius-newest/suricata/common.py" in get_system_config_buffer
261. suricata = suricata[0]
File "/usr/local/lib/python2.7/dist-packages/django/db/models/query.py" in getitem
201. return list(qs)[0]