### PR TITLE
Remove urllib3 version restriction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ PyYAML
 requests
 six
 smmap
-urllib3<1.17
+urllib3
 ipy
 elasticsearch
 django-ipware


### PR DESCRIPTION
Per https://github.com/TracyWebTech/django-revproxy/pull/88, revproxy now supports newer versions of urllib3.