### PR TITLE
Pin django-filter version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ django-ipware
 gunicorn
 djangorestframework
 markdown
-django-filter
+django-filter<2.0
 idstools
 enum34
 drf-schema-adapter


### PR DESCRIPTION
Per https://github.com/carltongibson/django-filter/issues/942, django-filter 2.0 and up are incompatible with Python 2.7. Fixes #141.