### PR TITLE
Don't choke if directories merely end with "rules"

### DIFF
--- a/rules/models.py
+++ b/rules/models.py
@@ -580,7 +580,7 @@ class Source(models.Model):
             # don't allow tar file with file in root dir
             if member.isfile() and not '/' in member.name:
                 raise SuspiciousOperation("Suspect tar file contains file in root directory '%s' instead of under 'rules' directory" % (member.name))
-            if member.isdir() and member.name.endswith('rules'):
+            if member.isdir() and ('/' + member.name).endswith('/rules'):
                 if rules_dir:
                     raise SuspiciousOperation("Tar file contains two 'rules' directory instead of one")
                 dir_list.append(member)


### PR DESCRIPTION
The Snort VRT rules tarballs, for example, have `rules`, `preproc_rules`, and `so_rules` directories. The check here needs to find directories literally named "rules", whether at the root or nested, but should not fail on these other cases.