### PR TITLE
Default STATIC_ROOT and database paths

### DIFF
--- a/scirius/settings.py
+++ b/scirius/settings.py
@@ -91,7 +91,7 @@ WSGI_APPLICATION = 'scirius.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'NAME': os.path.join(BASE_DIR, 'data', 'db.sqlite3'),
     }
 }
 
@@ -161,6 +161,7 @@ DRF_AUTO_METADATA_ADAPTER = 'drf_auto_endpoint.adapters.ReactJsonSchemaAdapter'
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
 STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 # Suricata binary
 SURICATA_BINARY = "suricata"


### PR DESCRIPTION
Without STATIC_ROOT, the project won't start at all, so there should be a default. Since the default DB path was originally under BASE_DIR, it makes sense that the static path would be too.

Furthermore, the DB itself should be stored in a folder dedicated to Scirius data; otherwise it's not clear which files should be persistent.(Also, you can't mount a Docker volume onto a single file!)