### PR TITLE
Add default STATIC_ROOT and update documentation

### DIFF
--- a/doc/installation-ce.rst
+++ b/doc/installation-ce.rst
@@ -58,9 +58,10 @@ account ::
 
  python manage.py createsuperuser
 
-Before starting the application you need to construct the bundles by running webpack ::
+Before starting the application you need to construct the bundles by running webpack and collect static files::
 
  webpack
+ python manage.py collectstatic
 
 This step as to be done after each code update.
 

--- a/scirius/settings.py
+++ b/scirius/settings.py
@@ -206,6 +206,7 @@ REST_FRAMEWORK = {
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
 STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 # Suricata binary
 SURICATA_BINARY = "suricata"


### PR DESCRIPTION
Referencing #177 and #149.
Currently, static files are not correctly collected following the installation instructions in the documentation, consequently making scirius appear without css. Running
```
python manage.py collectstatic
```
will collect the static files correctly.
However, this step will fail if the value of STATIC_ROOT is not set. Therefore a default value should be provided in the settings.py. The value basedir / static was chosen because it seemed reasonable.