### PR TITLE
add KIBANA7_DASHBOARDS_PATH variable in settings.py

### DIFF
--- a/scirius/settings.py
+++ b/scirius/settings.py
@@ -262,6 +262,7 @@ KIBANA_INDEX = "kibana-int"
 # Path to Kibana's dashboards installation
 KIBANA_DASHBOARDS_PATH = '/opt/kibana-dashboards/'
 KIBANA6_DASHBOARDS_PATH = '/opt/kibana6-dashboards/'
+KIBANA7_DASHBOARDS_PATH = '/opt/kibana7-dashboards/'
 KIBANA_ALLOW_GRAPHQL = True
 
 USE_EVEBOX = False


### PR DESCRIPTION
KIBANA7_DASHBOARDS_PATH variable was missing from settings.py, therefore ignoring the files in [settings.py line 1905](https://github.com/StamusNetworks/scirius/blob/6823792da9f00a5f3b57e4b1780e0172e60b9293/rules/es_data.py#L1905)