### PR TITLE
Skip scripts based on USE_ELASTICSEARCH and USE_KIBANA

### DIFF
--- a/docker/scirius/bin/create_ILM_policy.sh
+++ b/docker/scirius/bin/create_ILM_policy.sh
@@ -21,6 +21,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+if ! python manage.py diffsettings --all | grep -F 'USE_ELASTICSEARCH' | grep -qiF 'true'; then
+  echo 'Found USE_ELASTICSEARCH=False, not creating ILM policy'
+  exit 0
+fi
+
 while true
 do
   ELASTICSEARCH_ADDRESS=$(python manage.py diffsettings --all |grep 'ELASTICSEARCH_ADDRESS' | cut -d"'" -f 2)

--- a/docker/scirius/bin/reset_dashboards.sh
+++ b/docker/scirius/bin/reset_dashboards.sh
@@ -18,6 +18,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+if ! python manage.py diffsettings --all | grep -F 'USE_KIBANA' | grep -qiF 'true'; then
+  echo 'Found USE_KIBANA=False, skipping Kibana dashboards reset'
+  exit 0
+fi
+
 cd /opt/scirius/
 
 KIBANA_LOADED="/data/kibana_dashboards"


### PR DESCRIPTION
Closes #269.

Skip initialization scripts for Elasticsearch/Kibana if their
corresponding USE_XX variables are False.