### PR TITLE
Adopt newer suricata EVE json dns.queries field

### DIFF
--- a/rules/filter_sets.py
+++ b/rules/filter_sets.py
@@ -469,9 +469,9 @@ FILTER_SETS = [
             {
                 'negated': False,
                 'fullString': False,
-                'id': 'dns.query.rrname',
+                'id': 'dns.queries.rrname',
                 'value': '*',
-                'label': 'dns.query.rrname: *'
+                'label': 'dns.queries.rrname: *'
             }
         ],
         'name': 'Hunt: DNS related events',

--- a/rules/models.py
+++ b/rules/models.py
@@ -159,8 +159,8 @@ _HUNT_FILTERS = [
                 'id': 'dns',
                 'title': 'DNS',
                 'filterValues': [
-                    {'id': 'query.rrname', 'title': 'Query Name'},
-                    {'id': 'query.rrtype', 'title': 'Query Type'},
+                    {'id': 'queries.rrname', 'title': 'Query Name'},
+                    {'id': 'queries.rrtype', 'title': 'Query Type'},
                 ]
             },
             {

--- a/scirius/views.py
+++ b/scirius/views.py
@@ -104,7 +104,12 @@ def static_redirect(request, static_path):
     return response
 
 
-@csp(DEFAULT_SRC=["'self'"], SCRIPT_SRC=[], STYLE_SRC=["'self'", "'unsafe-inline'"], IMG_SRC=["'self'", "data:", '*'])
+@csp({
+    "default-src": ["'self'"],
+    "script-src": ["'self'"],
+    "style-src": ["'self'", "'unsafe-inline'"],
+    "img-src": ["'self'", "data:", "*"]
+})
 @permission_required('rules.events_view', raise_exception=True)
 def ui_view(request, red_path):
     context = {'current_user_url': reverse('current_user')}

--- a/ui/app/RulePage.js
+++ b/ui/app/RulePage.js
@@ -264,14 +264,14 @@ class RulePage extends React.Component {
                     <HuntStat
                       title="Name"
                       filters={this.props.filters}
-                      item="dns.query.rrname"
+                      item="dns.queries.rrname"
                       filterParams={this.props.filterParams}
                       loadMore={this.loadMore}
                     />
                     <HuntStat
                       title="Type"
                       filters={this.props.filters}
-                      item="dns.query.rrtype"
+                      item="dns.queries.rrtype"
                       filterParams={this.props.filterParams}
                       loadMore={this.loadMore}
                     />

--- a/ui/app/config/Dashboard.js
+++ b/ui/app/config/Dashboard.js
@@ -216,11 +216,11 @@ export const dashboard = [
     position: 12,
     items: [
       {
-        i: 'dns.query.rrname',
+        i: 'dns.queries.rrname',
         title: 'Names',
       },
       {
-        i: 'dns.query.rrtype',
+        i: 'dns.queries.rrtype',
         title: 'Types',
       },
     ],

--- a/ui/app/maps/Filters.js
+++ b/ui/app/maps/Filters.js
@@ -338,13 +338,13 @@ export const FiltersList = [
   },
   {
     title: 'Queried Name',
-    id: 'dns.query.rrname',
+    id: 'dns.queries.rrname',
     type: FilterType.HOSTNAME,
     category: FilterCategory.EVENT,
   },
   {
     title: 'Queried Type',
-    id: 'dns.query.rrtype',
+    id: 'dns.queries.rrtype',
     category: FilterCategory.EVENT,
   },
   {

--- a/ui/app/maps/FiltersDropdownItems.js
+++ b/ui/app/maps/FiltersDropdownItems.js
@@ -13,7 +13,7 @@ const FiltersDropdownItems = {
         {
           id: 'dns',
           label: 'DNS',
-          children: [{ id: 'dns.query.rrname' }, { id: 'dns.query.rrtype' }],
+          children: [{ id: 'dns.queries.rrname' }, { id: 'dns.queries.rrtype' }],
         },
         {
           id: 'http',

--- a/ui/app/pages/Events/components/AlertItem/index.js
+++ b/ui/app/pages/Events/components/AlertItem/index.js
@@ -522,16 +522,16 @@ class AlertItem extends React.Component {
               <UICard data-test="alert-card-DNS" title="DNS" fullHeight>
                 <DlHorizontal>
                   {_.isEmpty(data.dns) && <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />}
-                  {data.dns?.query?.map(query => (
+                  {data.dns?.queries?.map(query => (
                     <>
                       {query.rrname && (
                         <ErrorHandler>
-                          <EventField filter={new Filter('dns.query.rrname', query.rrname)} />
+                          <EventField filter={new Filter('dns.queries.rrname', query.rrname)} />
                         </ErrorHandler>
                       )}
                       {query.rrtype && (
                         <ErrorHandler>
-                          <EventField filter={new Filter('dns.query.rrtype', query.rrtype)} />
+                          <EventField filter={new Filter('dns.queries.rrtype', query.rrtype)} />
                         </ErrorHandler>
                       )}
                     </>


### PR DESCRIPTION
This fixes the missing `dns.queries` field in Suricata's EVE JSON format for DNS events.

It's too hard to maintain compatibility with the older format without complex modifications (see [attempted approach](https://github.com/dixyes/scirius/tree/fix-dns-query)). Due to my lack of understanding of the project, I chose to simply replace `query` with `queries`.

Also, django `csp` decorator changed, there is a commit for it.